### PR TITLE
upgrade: stop overwriting config.ini on upgrade

### DIFF
--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -42,15 +42,6 @@ pushd $install_dir
 popd
 
 #=================================================
-# UPDATE A CONFIG FILE
-#=================================================
-ynh_script_progression "Updating configuration..."
-
-ynh_config_add --template="config.ini" --destination="$install_dir/config.ini"
-
-chmod 600 "$install_dir/config.ini"
-
-#=================================================
 # START SYSTEMD SERVICE
 #=================================================
 ynh_script_progression "Starting $app's systemd service..."


### PR DESCRIPTION
## Problem

- Your configuration settings (modified from writefreely's UI) are overwritten and destroyed on upgrade. See #118 

## Solution

- Remove re-creation of config.ini on upgrade
- If new configuration keys are introduced in WriteFreely, they will be added to config.ini the next time the configuration is saved via the app’s CLI or admin interface. There’s no need to reset the file from a template.

## PR Status

- [X] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

