### PR TITLE
Fix bad default smtp settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ For starting a minimalist, federated blog or an entire community
 
 [![🌐 Official app website](https://img.shields.io/badge/Official_app_website-darkgreen?style=for-the-badge)](https://writefreely.org)
 [![App Demo](https://img.shields.io/badge/App_Demo-blue?style=for-the-badge)](https://write.as/new)
-[![Version: 0.16.0~ynh2](https://img.shields.io/badge/Version-0.16.0~ynh2-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/writefreely/)
+[![Version: 0.16.0~ynh3](https://img.shields.io/badge/Version-0.16.0~ynh3-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/writefreely/)
 
 <div align="center">
 <a href="https://apps.yunohost.org/app/writefreely"><img height="100px" src="https://github.com/YunoHost/yunohost-artwork/raw/refs/heads/main/badges/neopossum-badges/badge_more_info_on_the_appstore.svg"/></a>

--- a/conf/config.ini
+++ b/conf/config.ini
@@ -58,7 +58,7 @@ smtp_host             = 127.0.0.1
 smtp_port             = 25
 smtp_username         =	__APP__
 smtp_password         = __MAIL_PWD__
-smtp_enable_start_tls = true
+smtp_enable_start_tls = false
 
 [oauth.slack]
 client_id          = 

--- a/manifest.toml
+++ b/manifest.toml
@@ -5,7 +5,7 @@ name = "WriteFreely"
 description.en = "For starting a minimalist, federated blog or an entire community"
 description.fr = "Permet de créer un blog fédéré minimaliste ou une communauté entière"
 
-version = "0.16.0~ynh2"
+version = "0.16.0~ynh3"
 
 maintainers = ["trendless"]
 

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -28,9 +28,13 @@ if ynh_app_upgrading_from_version_before_or_equal_to 0.16.0~ynh2; then
 	smtp_host=$(ynh_read_var_in_file --file=$install_dir/config.ini --key=smtp_host)
 	smtp_port=$(ynh_read_var_in_file --file=$install_dir/config.ini --key=smtp_port)
 	smtp_enable_start_tls=$(ynh_read_var_in_file --file=$install_dir/config.ini --key=smtp_enable_start_tls)
-	if $smtp_enable_start_tls=true && $smtp_port=25 && $smtp_host=127.0.0.1; then
-		ynh_script_progression "setting starttls false..."
-		ynh_write_var_in_file --file=$install_dir/config.ini  --key=smtp_enable_start_tls --value=false
+	if $smtp_enable_start_tls=true; then
+		if $smtp_port=25; then
+			if $smtp_host=127.0.0.1; then
+				ynh_script_progression "setting starttls false..."
+				ynh_write_var_in_file --file=$install_dir/config.ini  --key=smtp_enable_start_tls --value=false
+			fi
+		fi
 	fi
 fi
 

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -28,13 +28,9 @@ if ynh_app_upgrading_from_version_before_or_equal_to 0.16.0~ynh2; then
 	smtp_host=$(ynh_read_var_in_file --file=$install_dir/config.ini --key=smtp_host)
 	smtp_port=$(ynh_read_var_in_file --file=$install_dir/config.ini --key=smtp_port)
 	smtp_enable_start_tls=$(ynh_read_var_in_file --file=$install_dir/config.ini --key=smtp_enable_start_tls)
-	if $smtp_enable_start_tls=true; then
-		if $smtp_port=25; then
-			if $smtp_host=127.0.0.1; then
-				ynh_script_progression "setting starttls false..."
-				ynh_write_var_in_file --file=$install_dir/config.ini  --key=smtp_enable_start_tls --value=false
-			fi
-		fi
+	if [[ "$smtp_enable_start_tls" == "true"  &&  "$smtp_port" == "25" && "$smtp_host" == "127.0.0.1" ]]; then
+		ynh_script_progression "setting starttls false..."
+		ynh_write_var_in_file --file=$install_dir/config.ini  --key=smtp_enable_start_tls --value=false
 	fi
 fi
 

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -20,6 +20,21 @@ ynh_script_progression "Updating source files..."
 ynh_setup_source --dest_dir="$install_dir" --full_replace=1 --keep=config.ini
 
 #=================================================
+# ADJUST CONFIG.INI SMTP_ENABLE_START_TLS VALUE
+#=================================================
+
+if ynh_app_upgrading_from_version_before_or_equal_to 0.16.0~ynh2; then
+	ynh_script_progression "getting smtp variables..."
+	smtp_host=$(ynh_read_var_in_file --file=$install_dir/config.ini --key=smtp_host)
+	smtp_port=$(ynh_read_var_in_file --file=$install_dir/config.ini --key=smtp_port)
+	smtp_enable_start_tls=$(ynh_read_var_in_file --file=$install_dir/config.ini --key=smtp_enable_start_tls)
+	if $smtp_enable_start_tls=true && $smtp_port=25 && $smtp_host=127.0.0.1; then
+		ynh_script_progression "setting starttls false..."
+		ynh_write_var_in_file --file=$install_dir/config.ini  --key=smtp_enable_start_tls --value=false
+	fi
+fi
+
+#=================================================
 # UPDATE SYSTEM CONFIGURATION
 #=================================================
 
@@ -32,7 +47,7 @@ ynh_config_add_systemd
 yunohost service add $app --description="WriteFreely daemon" --log="/var/log/$app/$app.log"
 
 #=================================================
-# MAKE THE UPGRADE
+# UPGRADE APP
 #=================================================
 
 ynh_script_progression "Upgrading $app..."

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -24,7 +24,7 @@ ynh_setup_source --dest_dir="$install_dir" --full_replace=1 --keep=config.ini
 #=================================================
 
 if ynh_app_upgrading_from_version_before_or_equal_to 0.16.0~ynh2; then
-	ynh_script_progression "getting smtp variables..."
+	ynh_script_progression "checking smtp config..."
 	smtp_host=$(ynh_read_var_in_file --file=$install_dir/config.ini --key=smtp_host)
 	smtp_port=$(ynh_read_var_in_file --file=$install_dir/config.ini --key=smtp_port)
 	smtp_enable_start_tls=$(ynh_read_var_in_file --file=$install_dir/config.ini --key=smtp_enable_start_tls)


### PR DESCRIPTION
## Problem

- `smtp_enable_start_tls` set to `true` by default settings in config.ini; causes email sending to fail

## Solution

- set to `false` in config.ini template; check existing installations 0.16.0~ynh2 and earlier for smtp tls `true`, host `127.0.0.1`, and port `25`; if all true, set smtp tls to `false`

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

!testme
!gogogadgetoci
By the power of systemd, I invoke The Great App CI to test this Pull Request!
